### PR TITLE
Bump stack resolver

### DIFF
--- a/i3ipc.cabal
+++ b/i3ipc.cabal
@@ -29,7 +29,7 @@ library
                      , binary               >= 0.8.6 && < 0.10
                      , text                 >= 1.2.1.0 && < 1.3
                      , vector               >= 0.11.0 && < 0.13
-                     , network              >= 2.6.3.5 && < 3.1
+                     , network              >= 2.6.3.5 && < 3.2
                      , typed-process        >= 0.2.4 && < 0.3
                      , exceptions           >= 0.8.1 && < 0.10.5
                      

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.9
+resolver: lts-15.10
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 496697
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/9.yaml
-    sha256: 3846ba7d13dd1b2679426dc3f450332a3b8a181063b0f3fc2d0c7d55db2e9c24
-  original: lts-13.9
+    size: 493124
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/10.yaml
+    sha256: 48bc6d1d59224a5166265ef6cdda6a512f29ecc8ef7331826312b82377e89507
+  original: lts-15.10


### PR DESCRIPTION
i3ipc fails to build with the latest Stack LTS due to the upper bound on `network`. This PR loosens the bound, and bumps the resolver to ensure that it still builds and passes tests.