### PR TITLE
Add test assets to extra-source-files

### DIFF
--- a/i3ipc.cabal
+++ b/i3ipc.cabal
@@ -12,7 +12,7 @@ synopsis:            A type-safe wrapper around i3's IPC
 copyright:           2019 Evan Cameron
 category:            Lib
 build-type:          Simple
-extra-source-files:  README.md
+extra-source-files:  README.md test/event/*.json test/reply/*.json
 cabal-version:       >=1.10
 
 library


### PR DESCRIPTION
`i3ipc` is marked broken in `nixpkgs` and I assume it's because it doesn't build properly in `nix`. Building it manually it seems the reason is simple: the source distribution is missing the `.json` files used in the test suite (`nixpkgs` run test suites to verify packages). `cabal sdist` includes the additional files + the tests seem to run correctly with this little change, hopefully unbreaking `i3ipc` in `nixpkgs` on the next release.

Thanks for your package. I've been doing a lot of this myself before I found this. Haven't used it yet though as I thought I'd fix it first.